### PR TITLE
feat: improve workflow steps and triggers

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,6 +2,13 @@ name: "Continuous Integration"
 run-name: Running tests on "${{ github.ref }}" by "${{ github.actor }}"
 on:
   push:
+    branches:
+      - 'main'
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
   workflow_dispatch:
   schedule:
   - cron: "0 12 1 * *"
@@ -11,6 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - uses: astral-sh/setup-uv@v5
       - run: cd qasports && uv sync
       - run: cd qasports && uv run ruff check .


### PR DESCRIPTION
# fix: Add pull request trigger to GitHub Actions

## Description
This pull request modifies the GitHub Actions workflow configurations to include pull_request as an additional event trigger.

Previously, our workflows might have only been triggered by push events (e.g., to main or other branches). This meant that automated checks (like linting, testing, or build validations) were only run after changes were merged or pushed directly, rather than during the review process.

By adding pull_request to the on: section of our workflows, we ensure that these crucial checks are executed automatically whenever a pull request is opened, synchronized, or reopened.